### PR TITLE
fix(useLocation): URL query may not be cleared when route switch

### DIFF
--- a/packages/axii-components/package-lock.json
+++ b/packages/axii-components/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "axii-components",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.14",
+      "name": "axii-components",
+      "version": "1.3.15",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^5.0.1",

--- a/packages/axii-components/package.json
+++ b/packages/axii-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axii-components",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "",
   "dependencies": {
     "@ant-design/colors": "^5.0.1",

--- a/packages/axii-components/src/hooks/useLocation.js
+++ b/packages/axii-components/src/hooks/useLocation.js
@@ -1,4 +1,4 @@
-import { createBrowserHistory } from 'history';
+import { createBrowserHistory, parsePath } from 'history';
 import { reactive, debounceComputed, replace } from 'axii'
 import { isEmptyObject } from '../util';
 
@@ -97,7 +97,10 @@ export default function useLocation(
 			debounceComputed(() => Object.assign(reactiveValues.query, partial))
 		},
 		goto(url) {
-			history.push(url)
+			history.push({
+				search: undefined,
+				...parsePath(url)
+			})
 		},
 	};
 }


### PR DESCRIPTION
由 history 导致的问题，在 push 新路由时，如果新路由不存在 query 信息，旧路由存在 query，则会在 push 之后保留旧路由的 query。

[push](https://github.com/remix-run/history/blob/main/packages/history/index.ts#L476) -> [getNextLocation](https://github.com/remix-run/history/blob/main/packages/history/index.ts#L686) -> [parsePath](https://github.com/remix-run/history/blob/bb756f4ba2da9a6a9edbd6d716b1c2b5575621f8/packages/history/index.ts#L1053)

## Reproduction

https://codesandbox.io/s/clever-darkness-hcpxx?file=/src/App.js

### Steps:

1. click `has query url` button
2. click `no query url` button
3. check url